### PR TITLE
show protected icons not showing inline

### DIFF
--- a/showprotected/plugin.js
+++ b/showprotected/plugin.js
@@ -22,7 +22,7 @@ CKEDITOR.plugins.add( 'showprotected', {
 		var template = '.%2 showprotected-img.cke_protected' +
 			'{' +
 				baseStyle +
-				'display:block;' +
+				'display:inline-block;' +
 				'width:16px;' +
 				'min-height:15px;' +
 				'line-height:1.6em;' +


### PR DESCRIPTION
We're finding that, since the latest version of CKEditor, the icons for protected code are all showing at the left margin, even if they are meant to be in the middle of text. In our testing, it appears to correct the issue if we change the css display for the images to be "inline-block" instead of "block". Thanks!
